### PR TITLE
Add "Timers" documentation detailing tick-time conversion and NetworkTimer

### DIFF
--- a/articles/timers.md
+++ b/articles/timers.md
@@ -1,0 +1,76 @@
+# Timers
+
+Netick provides several ways to work with time in your networked game.
+
+## Converting Between Ticks and Time
+
+Sometimes you need to convert between ticks and time (in seconds). Netick provides methods to do this conversion:
+
+### Sandbox.TickToTime()
+
+The `TickToTime()` method converts ticks to time in seconds. This is useful when you need to check if a certain amount of time has passed since an event occurred. For example, if you want to explode a bomb after a delay:
+
+```csharp
+public override void NetworkFixedUpdate()
+{
+    if (Sandbox.TickToTime(Sandbox.Tick - Object.SpawnTick) >= ExplosionDelay)
+        Explode();
+}
+```
+
+In this example, `Sandbox.Tick` is the current tick, `Object.SpawnTick` is the tick when the object was spawned, and `ExplosionDelay` is the delay in seconds before the explosion. The difference between the current tick and spawn tick determines the number of ticks that have passed since the object was spawned, which is then converted to seconds using `TickToTime()`.
+
+### Sandbox.TimeToTick()
+
+The `TimeToTick()` method does the opposite conversion, from time in seconds to ticks:
+
+```csharp
+// Convert time in seconds to ticks
+Tick tickValue = Sandbox.TimeToTick(timeInSeconds);
+```
+
+## Using NetworkTimer
+
+Netick provides a `NetworkTimer` class that makes it easier to work with time-based events in your networked game. The `NetworkTimer` class offers methods to check if a timer is running, if it has stopped, and how much time remains.
+
+### Starting a Timer
+
+You can start a timer using the `Sandbox.StartTimer()` method:
+
+```csharp
+// Start a 5-seconds timer
+NetworkTimer myNetworkTimer = Sandbox.StartTimer(5.0f);
+```
+
+> [!Note]
+> By default, the system uses predicted timing. You can use `usePredictedTiming: false` to opt out of this feature: `Sandbox.StartTimer(duration, usePredictedTiming: false)`.
+
+### Checking Timer Status
+
+You can check the status of a timer using the following methods:
+
+```csharp
+// Check if the timer is still running
+if (myNetworkTimer.IsRunning(Sandbox))
+{
+    // Timer is still running
+}
+
+// Check if the timer has stopped
+if (myNetworkTimer.IsStopped(Sandbox))
+{
+    // Timer has stopped/finished
+}
+```
+
+### Getting Remaining and Elapsed Time
+
+You can get the remaining time and elapsed time of a timer:
+
+```csharp
+// Get the remaining time in seconds
+float remainingTime = myNetworkTimer.GetRemainingTime(Sandbox);
+
+// Get the elapsed time in seconds
+float elapsedTime = myNetworkTimer.GetElapsedTime(Sandbox);
+```

--- a/articles/toc.md
+++ b/articles/toc.md
@@ -50,6 +50,8 @@
 
 ## [Sandboxing](sandboxing.md)
 
+## [Timers](timers.md)
+
 ## [Physics Prediction](physics-prediction.md)
 
 ## [Interpolation](interpolation.md)
@@ -93,7 +95,3 @@
 ## [Available Transports](transports.md)
 
 ## [How to Write a Transport Wrapper (Guide)](how-to-write-a-transport-wrapper.md)
-
-
-
-


### PR DESCRIPTION
This PR adds a new "Timers" section covering time conversion methods and NetworkTimer usage.

**Fair warning:** My Netick knowledge is VERY basic, so please double-check everything I wrote! I might have missed important details or gotten things wrong.

As someone just starting with Netick, I had no idea timers even existed until I saw someone mention them on Discord. That got me curious enough to dig into the API and figure out how it works. Since there wasn't any documentation on this, I thought I'd write up some basics, so people are aware of this feature, before rushing into custom solutions.

This section could definitely be improved by someone with more knowledge, especially on:
- How Ticks correlate to Time specifically
- Whether it's recommended to use Tick-based timers or NetworkTimers
- When turning off predicted timing might be beneficial or encouraged